### PR TITLE
fix: handle promises resolving the same value better

### DIFF
--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -19,10 +19,10 @@ import {
   type ThisEncode,
 } from "./utils.js";
 
-export function flatten(this: ThisEncode, input: unknown): number {
+export function flatten(this: ThisEncode, input: unknown, opts?: { ignoreExisting?: boolean }): number {
   const { indices } = this;
   const existing = indices.get(input);
-  if (existing) return existing;
+  if (existing && !opts?.ignoreExisting) return existing;
 
   if (input === undefined) return UNDEFINED;
   if (input === null) return NULL;

--- a/src/turbo-stream.spec.ts
+++ b/src/turbo-stream.spec.ts
@@ -200,6 +200,16 @@ test("should encode and decode object with promises as values", async () => {
   await decoded.done;
 });
 
+test("should encode and decode object with two equal promises as values", async () => {
+  const input = { foo: Promise.resolve("same"), bar: Promise.resolve("same") };
+  const decoded = await decode(encode(input));
+  const value = decoded.value as typeof input;
+  expect(value).toEqual({ foo: expect.any(Promise), bar: expect.any(Promise) });
+  expect(await value.foo).toEqual(await input.foo);
+  expect(await value.bar).toEqual(await input.bar);
+  await decoded.done;
+});
+
 test("should encode and decode object with rejected promise", async () => {
   const input = { foo: Promise.reject(new Error("bar")) };
   const decoded = await decode(encode(input));

--- a/src/turbo-stream.ts
+++ b/src/turbo-stream.ts
@@ -168,7 +168,10 @@ export function encode(
             )
               .then(
                 (resolved) => {
-                  const id = flatten.call(encoder, resolved);
+                  // flatten without checking for existing values as they can't be referenced in the promise response
+                  const id = flatten.call(encoder, resolved, {
+                    ignoreExisting: true,
+                  });
                   if (id < 0) {
                     controller.enqueue(
                       textEncoder.encode(`${TYPE_PROMISE}${deferredId}:${id}\n`)


### PR DESCRIPTION
Hi,

this is a sample solution for #28 that causes the values of resolved promises with values, that have already been sent to be sent again.

Happy to adjust if this for a better solution given a hint 😀 

Best, Vincent