### PR TITLE
fix: encoding of previously-used values

### DIFF
--- a/src/turbo-stream.ts
+++ b/src/turbo-stream.ts
@@ -181,6 +181,8 @@ export function encode(
                         `${TYPE_PROMISE}${deferredId}:[["${TYPE_PREVIOUS_RESOLVED}",${id[0]}]]\n`
                       )
                     );
+                    encoder.index++;
+                    lastSentIndex++;
                   } else if (id < 0) {
                     controller.enqueue(
                       textEncoder.encode(`${TYPE_PROMISE}${deferredId}:${id}\n`)
@@ -213,6 +215,8 @@ export function encode(
                         `${TYPE_ERROR}${deferredId}:[["${TYPE_PREVIOUS_RESOLVED}",${id[0]}]]\n`
                       )
                     );
+                    encoder.index++;
+                    lastSentIndex++;
                   } else if (id < 0) {
                     controller.enqueue(
                       textEncoder.encode(`${TYPE_ERROR}${deferredId}:${id}\n`)


### PR DESCRIPTION
I had more occurrences of #36 in my project, and I was able to isolate the issue much better. I believe this test is the absolute minimal case.

Reused values certainly work in many other scenarios, but this specific setup results in a circular reference for the third object key: `data`.
- if the value for `data` is not an object, no failure occurs
- if `'baz'` is not used as object value in 'foo', or if it _is_ an object value in `bar`, no failure occurs.

---

In my codebase, `foo`, `bar`, and `data` are all independent promises resolved from a Remix loader. When `data` resolves prior to `bar`, no failure occurs. The PREVIOUSLY_RESOLVED value must resolve prior to the data object. In doing so, it seems it taints either the `values` or `hydrated` cache in `unflatten`