### PR TITLE
add failing test for Invalid Date

### DIFF
--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -107,7 +107,8 @@ function stringify(this: ThisEncode, input: unknown, index: number) {
                 (i in input ? flatten.call(this, input[i]) : HOLE);
             str[index] = `${result}]`;
           } else if (input instanceof Date) {
-            str[index] = `["${TYPE_DATE}",${input.getTime()}]`;
+            const t = input.getTime()
+            str[index] = `["${TYPE_DATE}",${isNaN(t) ? '""' : t}]`;
           } else if (input instanceof URL) {
             str[index] = `["${TYPE_URL}",${JSON.stringify(input.href)}]`;
           } else if (input instanceof RegExp) {

--- a/src/turbo-stream.spec.ts
+++ b/src/turbo-stream.spec.ts
@@ -52,8 +52,9 @@ test("should encode and decode Date", async () => {
 
 test("should encode and decode Invalid Date", async () => {
   const input = new Date('invalid');
-  const output = await quickDecode(encode(input));
-  expect(output).toEqual(input);
+  const output = await quickDecode(encode(input)) as Date;
+  expect(output?.toString()).toEqual('Invalid Date');
+  expect(output?.getTime()).toBe(NaN);
 });
 
 test("should encode and decode NaN", async () => {

--- a/src/turbo-stream.spec.ts
+++ b/src/turbo-stream.spec.ts
@@ -50,6 +50,12 @@ test("should encode and decode Date", async () => {
   expect(output).toEqual(input);
 });
 
+test("should encode and decode Invalid Date", async () => {
+  const input = new Date('invalid');
+  const output = await quickDecode(encode(input));
+  expect(output).toEqual(input);
+});
+
 test("should encode and decode NaN", async () => {
   const input = NaN;
   const output = await quickDecode(encode(input));


### PR DESCRIPTION
Invalid dates currently throw a SyntaxError during decoding, because `new Date('invalid').getTime()` returns NaN, which is invalid JSON.

I wasn't sure how you'd like to encode this, so I just created the test.