### PR TITLE
support encode and decode promise rejected with any value

### DIFF
--- a/src/turbo-stream.spec.ts
+++ b/src/turbo-stream.spec.ts
@@ -288,6 +288,15 @@ test("should encode and decode object with rejected promise", async () => {
   return decoded.done;
 });
 
+test("should encode and decode promise rejected with object", async () => {
+  const input = { foo: Promise.reject({ error: "bar" }) };
+  const decoded = await decode(encode(input));
+  const value = decoded.value as typeof input;
+  expect(value.foo).toBeInstanceOf(Promise);
+  expect(value.foo).rejects.toEqual(await input.foo.catch((reason) => reason));
+  return decoded.done;
+});
+
 test("should encode and decode set with promises as values", async () => {
   const prom = Promise.resolve("foo");
   const input = new Set([prom, prom]);

--- a/src/turbo-stream.ts
+++ b/src/turbo-stream.ts
@@ -226,13 +226,6 @@ export function encode(
                     }
                   },
                   (reason) => {
-                    if (
-                      !reason ||
-                      (typeof reason !== "object" && !(reason instanceof Error))
-                    ) {
-                      reason = new Error("An unknown error occurred");
-                    }
-
                     const id = flatten.call(encoder, reason);
                     if (Array.isArray(id)) {
                       controller.enqueue(

--- a/src/turbo-stream.ts
+++ b/src/turbo-stream.ts
@@ -228,8 +228,7 @@ export function encode(
                   (reason) => {
                     if (
                       !reason ||
-                      typeof reason !== "object" ||
-                      !(reason instanceof Error)
+                      (typeof reason !== "object" && !(reason instanceof Error))
                     ) {
                       reason = new Error("An unknown error occurred");
                     }


### PR DESCRIPTION
allow throwing any type of value from promises, my reasoning is that JS and react support throwing any kind of value so this lines up with JS and react semantics/expectations

see https://github.com/remix-run/react-router/issues/12676 for more background