### PR TITLE
fix: retain set and map order

### DIFF
--- a/src/turbo-stream.spec.ts
+++ b/src/turbo-stream.spec.ts
@@ -118,6 +118,7 @@ test("should encode and decode Map", async () => {
   ]);
   const output = await quickDecode(encode(input));
   expect(output).toEqual(input);
+  expect([...(output as Map<unknown, unknown>)]).toEqual([...input]);
 });
 
 test("should encode and decode empty Map", async () => {
@@ -130,6 +131,7 @@ test("should encode and decode Set", async () => {
   const input = new Set(["foo", "bar"]);
   const output = await quickDecode(encode(input));
   expect(output).toEqual(input);
+  expect([...(output as Set<unknown>)]).toEqual([...input]);
 });
 
 test("should encode and decode empty Set", async () => {


### PR DESCRIPTION
I was switching some Remix code from SuperJSON to the default `turbo-stream` handling in React Router and ran into issues because I was depending on the iteration order of `Set` and `Map`, which `turbo-stream` wasn't retaining. This caused "Hydration failed because the server rendered HTML didn't match the client" errors.

For my particular use-cases, I wanted some values and keys to be unique (hence the usage of `Set` and `Map`, respectively), but I also wanted them to be sorted, so I ensured the elements were inserted in the desired order and depended on that order when the data was sent over the client.

This PR retains the order.