### PR TITLE
Fix lazy component

### DIFF
--- a/fixtures/preact/src/ssr.tsx
+++ b/fixtures/preact/src/ssr.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, VNode } from "preact";
-import { lazy } from "preact/compat";
+import { lazy, createElement, Fragment } from "preact/compat";
 import { renderToStringAsync } from "preact-render-to-string";
 
 import {
@@ -58,11 +58,11 @@ const decodeClientReference: DecodeClientReferenceFunction<
 	EncodedClientReference
 > = (encoded) => {
 	const Comp = lazy(() =>
-		loadClientReference(encoded).then((Component: any) => ({
-			default: Component,
+		loadClientReference(encoded).then((C: any) => ({
+			default: () => C,
 		})),
 	);
-	return Comp as unknown as ComponentType;
+	return Comp as any as unknown as ComponentType;
 };
 
 // This escapeHtml utility is based on https://github.com/zertosh/htmlescape

--- a/fixtures/preact/src/ssr.tsx
+++ b/fixtures/preact/src/ssr.tsx
@@ -42,7 +42,7 @@ export async function prerender(
 
 	const rendered = await renderToStringAsync(
 		<>
-			{/* {payload} */}
+			{payload}
 			<script
 				dangerouslySetInnerHTML={{
 					__html: `window.PREACT_STREAM = new ReadableStream({ start(c) { c.enqueue(${escapeHtml(JSON.stringify(inlinePayload))}); c.close(); } });`,

--- a/src/preact.ts
+++ b/src/preact.ts
@@ -96,14 +96,13 @@ let preactDecode = ({
 				keyOrRendered !== null &&
 				typeof (keyOrRendered as any).then === "function"
 			) {
-				const component = compat.lazy(async () => {
-					const resolved = await keyOrRendered;
-					return {
-						default: resolved,
-					};
-				})
 				return {
-					value: component
+					value: preact.h(compat.lazy(async () => {
+						const resolved = await keyOrRendered;
+						return {
+							default: () => resolved as () => preact.ComponentType<any>,
+						};
+					}), null)
 				};
 			}
 			return {

--- a/src/preact.ts
+++ b/src/preact.ts
@@ -96,19 +96,14 @@ let preactDecode = ({
 				keyOrRendered !== null &&
 				typeof (keyOrRendered as any).then === "function"
 			) {
+				const component = compat.lazy(async () => {
+					const resolved = await keyOrRendered;
+					return {
+						default: resolved,
+					};
+				})
 				return {
-					value:
-						typeof document === "undefined"
-							? preact.h(
-									compat.lazy(async () => {
-										const resolved = await keyOrRendered;
-										return {
-											default: () => resolved,
-										};
-									}),
-									null,
-								)
-							: keyOrRendered,
+					value: component
 				};
 			}
 			return {


### PR DESCRIPTION
With this fix I get the following in the browser 
<img width="820" alt="Screenshot 2025-02-04 at 18 55 08" src="https://github.com/user-attachments/assets/f999ff3b-6d89-4504-b2a5-6463156028bb" />

Current issue seems to be that after decoding the client reference with the vite virtual module it gets a vnode withotu a type

```
Error: {"props":{},"__k":null,"__":null,"__b":0,"__e":null,"__c":null,"__v":1,"__i":-1,"__u":0} is not a valid HTML tag name in <[object Object]>
```

EDIT: ah, client references were returned as a vnode so doing `() => ` was needed else we were calling `createElement` with an already existing vnode.