### PR TITLE
Proposal

### DIFF
--- a/fixtures/preact/src/browser.tsx
+++ b/fixtures/preact/src/browser.tsx
@@ -1,7 +1,8 @@
 import { h, type ComponentType, type VNode } from "preact";
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { lazy, Suspense } from "preact/compat";
 import { createRoot, hydrateRoot } from "preact/compat/client";
+import 'preact/debug'
 
 import {
 	decode,
@@ -52,6 +53,7 @@ function getDataURL() {
 	const payload = await decode<VNode>(payloadStream, {
 		decodeClientReference,
 	});
+
 	const app = document.getElementById("app");
 	if (!app) throw new Error("No #app element");
 	if (window.PREACT_STREAM) {
@@ -105,11 +107,22 @@ const decodeClientReference: DecodeClientReferenceFunction<
 	if (cached) {
 		return cached;
 	}
-	const Comp = lazy(() =>
+
+	const LazyComponent = lazy(() =>
 		loadClientReference(encoded).then((Component: any) => ({
 			default: Component,
 		})),
 	) as ComponentType;
+
+	const Comp = () => {
+		const [hydrated, setHydrated] = useState(false);
+		useEffect(() => {
+			setHydrated(true)
+		}, []);
+
+		return hydrated ? <LazyComponent /> : null;
+	}
+
 	cache.set(key, Comp);
 	return Comp;
 };


### PR DESCRIPTION
This proposal counteracts hydration mismatches, the client components are delayed until hydration completes. When the server-components render enters the screen it will look like

```
<main>
  <ui>
  <gap>
  <ui>
  <gap>
```

These gaps are where the client components will slot in, if the lazy promises are present during hydration then Preact will "reserve" DOM-nodes to account for the yet-to-resolve component so it can resume hydration from there. Which we don't want, we can ofcourse already start fetching the component as an optimisation but we should not render the promise.

In https://github.com/preactjs/preact/issues/4442 we are actually fixing this but I am not sure whether that approach would work here as we aren't trying to render these promises on the server nor are we even willing to hydrate them so I think this is the best option to remove potential missmatches.