### PR TITLE
fix decoding exponential notation numbers

### DIFF
--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -106,6 +106,14 @@ describe("decode", () => {
 		expect(await quickDecode(3.14)).toBe(3.14);
 	});
 
+	test("1.469212113081042e-10", async () => {
+		expect(await quickDecode(1.469212113081042e-10)).toBe(1.469212113081042e-10);
+	});
+
+	test("1e+100", async () => {
+		expect(await quickDecode(1e+100)).toBe(1e+100);
+	});
+
 	test("bigint", async () => {
 		expect(await quickDecode(42n)).toBe(42n);
 	});
@@ -192,6 +200,14 @@ describe("decode", () => {
 		expect(decoded.a).toBe(decoded);
 	});
 
+	test("object with an exponential notation small number", async () => {
+		expect(await quickDecode({ a: 1.469212113081042e-10 })).toEqual({ a: 1.469212113081042e-10 });
+	});
+
+	test("object with an exponential notation large number", async () => {
+		expect(await quickDecode({ a: 1e100 })).toEqual({ a: 1e100 });
+	});
+
 	test("empty array", async () => {
 		expect(await quickDecode([])).toEqual([]);
 	});
@@ -210,6 +226,14 @@ describe("decode", () => {
 
 	test("array with nested object", async () => {
 		expect(await quickDecode([{ a: 1 }])).toEqual([{ a: 1 }]);
+	});
+
+	test("array with an exponential notation small number", async () => {
+		expect(await quickDecode([1.469212113081042e-10])).toEqual([1.469212113081042e-10]);
+	});
+
+	test("array with an exponential notation large number", async () => {
+		expect(await quickDecode([1e100])).toEqual([1e100]);
 	});
 
 	test("object toJSON", async () => {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -472,8 +472,10 @@ export async function decode<T>(
 				}
 			} else if (mode === MODE_NUMBER || mode === MODE_ASYNC) {
 				if (
+					charCode === 43 || // +
 					charCode === 45 || // -
 					charCode === 46 || // .
+					charCode === 101 || // e
 					(charCode >= 48 && charCode <= 57) // 0-9
 				) {
 					buffer += chunk[i];


### PR DESCRIPTION
This fixes decoding numbers like `1e-10` or `1e100` or `1e+100`.

Before this patch, encoding then decoding these numbers would loose the exponent:
```
> ts=require('turbo-stream')
> await ts.decode(ts.encode(1e100))
1
> await ts.decode(ts.encode(42e-42))
4.2
```

If a such a number was contained in an object or array, decode would throw:
```
> await ts.decode(ts.encode({ a: 1e100 }))
Uncaught SyntaxError: Unexpected character: 'e'
> await ts.decode(ts.encode([1e100]))
Uncaught SyntaxError: Unexpected character: 'e'
```